### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/web/server/package.json
+++ b/web/server/package.json
@@ -19,7 +19,8 @@
     "compression": "^1.8.0",
     "cross-env": "^7.0.3",
     "serve-static": "^2.2.0",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9",

--- a/web/server/src/index.js
+++ b/web/server/src/index.js
@@ -3,6 +3,7 @@ import { join } from 'path'
 import { readFileSync } from 'fs'
 import express from 'express'
 import serveStatic from 'serve-static'
+import RateLimit from 'express-rate-limit'
 import shopify from './shopify.js'
 import WebhookHandlers from './webhooks/webhooks.js'
 import productsRoutes from './routes/products.js'
@@ -17,6 +18,16 @@ const STATIC_PATH =
     : `${process.cwd()}/../client/`
 
 const app = express()
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+})
+
+// apply rate limiter to all requests
+app.use(limiter)
+
 app.use(express.raw({ type: 'application/json' }))
 
 // Set up Shopify authentication and webhook handling


### PR DESCRIPTION
Potential fix for [https://github.com/Mini-Sylar/shopify-app-vue-template/security/code-scanning/2](https://github.com/Mini-Sylar/shopify-app-vue-template/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all routes. This will ensure that the application is protected against denial-of-service attacks.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `web/server/src/index.js` file.
3. Configure the rate limiter with appropriate settings.
4. Apply the rate limiter middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
